### PR TITLE
TIC_80-Coding-Train-Logo

### DIFF
--- a/ports/TIC_80-Coding-Train-Logo
+++ b/ports/TIC_80-Coding-Train-Logo
@@ -1,0 +1,36 @@
+-- title: Coding Train logo for Hacktober
+-- author: Alesk 69
+-- script:  lua
+-- link: https://tic80.com/play?cart=3581
+function TIC()
+
+	cls(12)
+	
+	line (16, 27, 16, 21, 1);
+  line (16, 21, 14, 21, 1);
+  line (16, 21, 14, 21, 1);
+  line (14, 21, 14, 17, 1);
+  line (14, 17, 31, 17, 1);
+  line (31, 17, 31, 24, 1);
+ --Next part 
+  line(35, 24, 33, 17, 11);
+  line(34, 17, 42, 17, 11);
+  line(44, 17, 42, 24, 11);
+ --Next part 
+  line(49, 41, 45, 36, 2);
+  line(45, 36, 47, 30, 2);
+  line(47, 30, 45, 24, 2);
+  --
+  circb (21, 37, (4.5 * 2), 1); 
+ --
+  circb (34, 42, (2 * 2), 11);
+ --
+ 	circb (42, 42, (2 * 2), 11);
+ -- 
+ 	line(41, 27, 41, 33, 3);
+  line(38, 27, 38, 33, 3);
+  line(35, 27, 35, 33, 3);
+ --
+  line(42, 36, 34, 36, 3);  
+	
+end


### PR DESCRIPTION
A version of the Coding Train logo in the Tic 80 fantasy computer.

<!-- Template for submission of remixed Coding Train Logo -->

## Variation

- **Tic-80 (lua) hard-coded Coding Train Logo**
- **Alesk 69**
- **The logo can be seen on the Tic-80 official website: https:/tic80.com/play?cart=3581**
- **More information about the Tic-80 fantasy computer: https://tic80.com/learn**



 
